### PR TITLE
Search.php Corrections: Spelling & Variables

### DIFF
--- a/php/controller/search.php
+++ b/php/controller/search.php
@@ -13,31 +13,32 @@ function actions() {
       $address = $_POST['address'];
 
       if((strlen($address) != 0) && (strlen($phone) == 0)) {
-          $sqlVaues = handSQL('SELECT *
+          $sqlValues = handSQL('SELECT *
        from Visitors
-       where ((FName = :fname) && (LName = :lname) && (Address = :adress))
-       LIMIT 1', [':fname', ':lname', ':adress'], [$fName, $lName, $address], 0);
+       where ((FName = :fname) && (LName = :lname) && (Address = :address))
+       LIMIT 1', [':fname', ':lname', ':address'], [$fName, $lName, $address], 0);
       } elseif ((strlen($address) != 0) && (strlen($phone) == 0)) {
-          $sqlVaues = handSQL('SELECT *
+          $sqlValues = handSQL('SELECT *
        from Visitors
        where ((FName = :fname) && (LName = :lname) && (PhoneNumber = :phoneNumber))
        LIMIT 1', [':fname', ':lname', ':phoneNumber'], [$fName, $lName, $phone], 0);
       } elseif ((strlen($address) != 0) && (strlen($phone) != 0)) {
-          $sqlVaues = handSQL('SELECT *
+          $sqlValues = handSQL('SELECT *
        from Visitors
-       where ((FName = :fname) && (LName = :lname) && (PhoneNumber = :phoneNumber) && (Address = :adress))
-       LIMIT 1', [':fname', ':lname', ':phoneNumber',':adress'], [$fName, $lName, $phone, $address], 0);
+       where ((FName = :fname) && (LName = :lname) && (PhoneNumber = :phoneNumber) && (Address = :address))
+       LIMIT 1', [':fname', ':lname', ':phoneNumber',':address'], [$fName, $lName, $phone, $address], 0);
       } else {
-          $sqlVaues = handSQL('SELECT *
+          $sqlValues = handSQL('SELECT *
        from Visitors
        where ((FName = :fname) && (LName = :lname))
        LIMIT 1', [':fname', ':lname'], [$fName, $lName], 0);
       }
 
-      if ($sqlVaues == 0) {
+      if ($sqlValues == 0) {
         $_SESSION['found'] = false;
       } else {
-        $_SESSION['found'] = $sqlVaues;
+        $_SESSION['found'] = true;
+        $_SESSION['sqlValues'] = $sqlValues;
       }
       require('../view/HandleVisiter.php');
   } else {


### PR DESCRIPTION
**Spelling Corrections:**
 - ":adress" => ":address"
- "$sqlVaues" => "$sqlValues"

**Variable Corrections:**
- $_SESSION['found'] :
  - Change: Will only be true or false as described in beginning documentation of "php\view\HandleVisitor.php"
- $_SESSION['sqlValues']:
  - Change: Added session variable to code as a specific and clear way to access "$sqlValues"