### PR TITLE
Fixed Session issue

### DIFF
--- a/php/view/HandleVisiter.php
+++ b/php/view/HandleVisiter.php
@@ -1,4 +1,4 @@
-<?php session_start(); ?>
+<?php if(!isset($_SESSION)){ session_start(); } ?>
 <!--
 ====== DOCUMENT I\O INFO ======
 VARIABLES REQUIRED:


### PR DESCRIPTION
session_start() will now only be used if $_SESSION is not set. This prevents a session start when one is not needed. Particularly between the forms HandelVisiter.php ---> findPerson.php